### PR TITLE
Draft: Remove jax-md and rewrite periodic.py

### DIFF
--- a/glp/README.md
+++ b/glp/README.md
@@ -30,6 +30,6 @@ sh run.py
 
 ### Todos
 
-- [ ] Custom JVP to make derivatives of m.i.c. displacements correct
+- [x] Make cell derivatives of m.i.c. displacements correct; done! see https://github.com/sirmarcel/glp/pull/1
 - [ ] Make jit-table update of unfolding, following the pattern of the nighborlist
 - [ ] Upgrade neighborlist to cell list (enable scaling to larger systems)

--- a/glp/calculators/heat_flux_hardy.py
+++ b/glp/calculators/heat_flux_hardy.py
@@ -59,7 +59,7 @@ def calculator(
             R = stop_gradient(system.R)
 
             Ri = jnp.tile(R[i], N).reshape(-1, 3)
-            Rji = jax.vmap(displacement_fn)(Ri, R)
+            Rji = jax.vmap(displacement_fn)(R, Ri)
 
             hf = jnp.einsum("ja,jb,jb->a", Rji, grad, velocities)
 

--- a/glp/calculators/variations_atom_pair.py
+++ b/glp/calculators/variations_atom_pair.py
@@ -7,7 +7,6 @@ from glp.neighborlist import neighbor_list
 from glp.utils import cast
 
 from .calculator import Calculator
-from .utils import system_to_graph_without_mic
 
 
 def calculator(
@@ -42,10 +41,7 @@ def calculator(
     def calculator_fn(system, state, velocities=None, masses=None):
         state = update_neighbors(system, state)
 
-        if fractional_mic:
-            graph = system_to_graph(system, state)
-        else:
-            graph = system_to_graph_without_mic(system, state)
+        graph = system_to_graph(system, state)
 
         energy, grads = energies_and_derivatives_fn(graph)
         energy_and_energies, grads = energies_and_derivatives_fn(graph)

--- a/glp/calculators/variations_end_to_end.py
+++ b/glp/calculators/variations_end_to_end.py
@@ -5,7 +5,7 @@ from glp.graph import system_to_graph
 from glp.neighborlist import neighbor_list
 
 from .calculator import Calculator
-from .utils import strain_system, strain_graph, get_strain, system_to_graph_without_mic
+from .utils import strain_system, strain_graph, get_strain
 
 
 def calculator(
@@ -31,7 +31,7 @@ def calculator(
         def energy_fn(system, strain, state):
             state = update_neighbors(system, state)
             system = strain_system(system, strain)
-            graph = system_to_graph_without_mic(system, state)
+            graph = system_to_graph(system, state)
             return jnp.sum(potential(graph)), state
 
         energies_and_derivatives_fn = jax.value_and_grad(
@@ -54,7 +54,7 @@ def calculator(
 
         def energy_fn(system, state):
             state = update_neighbors(system, state)
-            graph = system_to_graph_without_mic(system, state)
+            graph = system_to_graph(system, state)
             return jnp.sum(potential(graph)), state
 
         energies_and_derivatives_fn = jax.value_and_grad(

--- a/glp/graph.py
+++ b/glp/graph.py
@@ -4,8 +4,8 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 
-from .system import to_displacement
 from .utils import cast
+from .periodic import displacement
 
 Graph = namedtuple("Graph", ("edges", "nodes", "centers", "others", "mask"))
 
@@ -17,10 +17,8 @@ def system_to_graph(system, neighbors):
     positions = system.R
     nodes = system.Z
 
-    displacement_fn = to_displacement(system)
-
-    edges = jax.vmap(displacement_fn)(
-        positions[neighbors.others], positions[neighbors.centers]
+    edges = jax.vmap(partial(displacement, system.cell))(
+        positions[neighbors.centers], positions[neighbors.others]
     )
 
     mask = neighbors.centers != positions.shape[0]

--- a/glp/periodic.py
+++ b/glp/periodic.py
@@ -1,47 +1,77 @@
+"""tools for dealing with periodicity
+
+Conventions:
+- `a,b,c,...` indicate real-space cartesian directions
+- `A,B,C,...` indicate lattice vectors or inverse lattice vectors
+- `R` are real-space vectors
+- `X` are fractional-coordinate vectors
+
+"""
+
+from jax import vmap
 import jax.numpy as jnp
-from jax_md import space
+from functools import partial
 
 from .utils import cast
 
-def displacement_frac(cell):
-    return space.periodic_general(cell, fractional_coordinates=True)[0]
+
+def inverse(cell):
+    return jnp.linalg.inv(cell)
 
 
-def displacement_real(cell):
-    return space.periodic_general(cell, fractional_coordinates=False)[0]
+def _to_frac(cell, R):
+    return jnp.einsum("Aa,a->A", inverse(cell), R)
 
 
-def to_frac(positions, cell):
-    inverse = space.inverse(cell)
-    return jnp.einsum("Aa,ia->iA", inverse, positions)
+def to_frac(cell, R):
+    return vmap(partial(_to_frac, cell))(R)
 
 
-def from_frac(fractional, cell):
-    return jnp.einsum("aA,iA->ia", cell, fractional)
+def _from_frac(cell, X):
+    return jnp.einsum("aA,A->a", cell, X)
 
 
-def wrap(positions, cell):
-    return from_frac(to_frac(positions, cell) % cast(1.0), cell)
+def from_frac(cell, X):
+    return vmap(partial(_from_frac, cell))(X)
 
 
-def project_on(R, normals):
-    return jnp.einsum("Ia,Aa->IA", R, normals)
+def make_displacement(cell):
+    return partial(displacement, cell)
 
 
-def get_heights(cell, normals=None):
-    if normals is None:
-        normals = get_normals(cell)
-    return jnp.diag(project_on(cell.T, normals))
+def displacement(cell, Ra, Rb):
+    if cell is None:
+        return Rb - Ra
+
+    else:
+        R = Rb - Ra
+        X = _to_frac(cell, R)
+        X = jnp.mod(X + cast(0.5), cast(1.0)) - cast(0.5)
+
+        return _from_frac(cell, X)
+
+
+def wrap(cell, R):
+    return from_frac(cell, to_frac(cell, R) % cast(1.0))
+
+
+def project_on(normals, R):
+    return jnp.einsum("Aa,ia->iA", normals, R)
+
+
+def get_heights(cell):
+    normals = get_normals(cell)
+    return jnp.diag(project_on(normals, cell.T))
 
 
 def get_normals(cell):
     # surface normals of cell boundaries
     # (i.e. normalised lattice vectors of reciprocal lattice)
     # convention: indexed by the lattice vector they're not orthogonal to
-    inv = space.inverse(cell)  # rows: inverse lattice vectors
+    inv = inverse(cell)  # rows: inverse lattice vectors
     normals = inv / jnp.linalg.norm(inv, axis=1)[:, None]
     return normals
 
 
-def project_on_normals(positions, cell):
-    return project_on(positions, get_normals(cell))
+def project_on_normals(cell, R):
+    return project_on(get_normals(cell), R)

--- a/glp/potentials/__init__.py
+++ b/glp/potentials/__init__.py
@@ -1,2 +1,2 @@
 from .potential import Potential
-from .lj import lennard_jones, lennard_jones_jax_md
+from .lj import lennard_jones

--- a/glp/system.py
+++ b/glp/system.py
@@ -2,7 +2,7 @@ from collections import namedtuple
 
 from jax import numpy as jnp
 
-from jax_md.space import periodic_general, free
+from .periodic import make_displacement
 
 System = namedtuple("System", ("R", "Z", "cell"))
 UnfoldedSystem = namedtuple("System", ("R", "Z", "cell", "mask", "replica_idx"))
@@ -10,13 +10,16 @@ UnfoldedSystem = namedtuple("System", ("R", "Z", "cell", "mask", "replica_idx"))
 
 def atoms_to_system(atoms, dtype=jnp.float32):
     R = jnp.array(atoms.get_positions(), dtype=dtype)
-    Z = jnp.array(atoms.get_atomic_numbers(), dtype=jnp.int32) # we will infer this type
+    Z = jnp.array(
+        atoms.get_atomic_numbers(), dtype=jnp.int32
+    )  # we will infer this type
     cell = jnp.array(atoms.get_cell().array.T, dtype=dtype)
     return System(R, Z, cell)
 
 
 def unfold_system(system, unfolding):
     from glp.unfold import unfold
+
     N = system.R.shape[0]
 
     wrapped, unfolded = unfold(system.R, system.cell, unfolding)
@@ -30,7 +33,4 @@ def unfold_system(system, unfolding):
 
 
 def to_displacement(system):
-    if system.cell is not None:
-        return periodic_general(system.cell, fractional_coordinates=False)[0]
-    else:
-        return free()[0]
+    return make_displacement(system.cell)

--- a/glp/unfold.py
+++ b/glp/unfold.py
@@ -36,7 +36,13 @@ from .unfold_numpy import _np_unfolding
 
 Unfolding = namedtuple(
     "Unfolding",
-    ("wrap_offsets", "replica_idx", "replica_offsets", "reference_positions", "reference_cell"),
+    (
+        "wrap_offsets",
+        "replica_idx",
+        "replica_offsets",
+        "reference_positions",
+        "reference_cell",
+    ),
 )
 Unfolder = namedtuple("Unfolder", ("unfolding", "needs_update"))
 
@@ -61,7 +67,7 @@ def unfolder(system, cutoff, skin):
         # of the cutoff -- we don't care about movement in the interior
         # (this is probably way too much optimisation)
         movements = system.R - unfolding.reference_positions
-        movements = jnp.abs(periodic.project_on_normals(movements, system.cell))
+        movements = jnp.abs(periodic.project_on_normals(system.cell, movements))
 
         # we just give up if the cell changes -- this should only happen during testing,
         # as the unfolded stuff should only be relevant for NVE
@@ -129,7 +135,7 @@ def get_wrapping(positions, cell):
     # compute the offsets needed to retvrn positions into cell,
     # easily computed by taking the div wrt 1.0 in fractional coords
 
-    frac = periodic.to_frac(positions, cell)
+    frac = periodic.to_frac(cell, positions)
     offsets = cast(-1.0) * (frac // cast(1.0)).astype(jnp.int32)
 
     return offsets

--- a/glp/unfold_numpy.py
+++ b/glp/unfold_numpy.py
@@ -50,9 +50,9 @@ def _np_unfolding(positions, cell, cutoff):
     (Alternatively, we could do this in scaled coordinates.)
 
     """
-    normals = periodic.get_normals(cell)
-    heights = periodic.get_heights(cell, normals=normals)
-    projections = periodic.project_on(positions, normals)
+
+    heights = periodic.get_heights(cell)
+    projections = periodic.project_on_normals(cell, positions)
 
     # projections = project_onto_planes(positions, cell)
 

--- a/glp/utils.py
+++ b/glp/utils.py
@@ -1,4 +1,4 @@
-from jax import jit
+from jax import jit, vmap
 import jax.numpy as jnp
 from functools import partial
 
@@ -50,3 +50,13 @@ def str_to_dtype(string):
         return jnp.float64
     else:
         raise ValueError(f"unknown dtype {string}")
+
+def squared_distance(R):
+    return jnp.sum(R ** cast(2.0), axis=-1)
+
+
+def distance(R):
+    r2 = squared_distance(R)
+    mask = r2 > cast(0)
+    safe_r2 = jnp.where(mask, r2, cast(0))
+    return jnp.where(mask, jnp.sqrt(safe_r2), cast(0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "glp"
-version = "0.1.0"
+version = "0.2.0"
 description = "forces, stress and heat flux for graph machine learning potentials"
 authors = ["Marcel Langer <dev@marcel.science>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = ">=3.7"
-jax-md = ">=0.2.5"
 comms = { git = "https://github.com/sirmarcel/comms.git", branch = "main" }
 specable = "*"
 numpy = "*"

--- a/tests/unit/test_neighborlist.py
+++ b/tests/unit/test_neighborlist.py
@@ -36,7 +36,7 @@ def filter_and_sort(distances, cutoff):
 
 
 def get_distances(graph):
-    from jax_md.space import distance
+    from glp.utils import distance
 
     return distance(graph.edges)[graph.mask]
 

--- a/tests/unit/test_periodic.py
+++ b/tests/unit/test_periodic.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+
+import numpy as np
+
+import jax
+import jax.numpy as jnp
+from ase import Atoms
+
+from glp import atoms_to_system
+from glp.neighborlist import neighbor_list
+from glp.graph import system_to_graph
+from glp.system import System
+
+
+class TestPeriodic(TestCase):
+    def test_basic(self):
+        # test a manually constructed example
+        # this fails with jax-md displacement functions, i.e. when using
+        # the following for periodic.displacement:
+        # from jax_md import space
+        # disp = space.periodic_general(cell, fractional_coordinates=False)[0]
+        # return disp(Rb, Ra)
+
+        atoms = Atoms(
+            positions=[[1.0, 0.0, 0], [2, 3, 0]],
+            cell=[[6, 0, 0], [2, 4, 0], [0, 0, 20]],
+            pbc=True,
+        )
+
+        reference = atoms.get_all_distances(mic=True, vector=True)
+
+        system = atoms_to_system(atoms)
+
+        neighbors, update = neighbor_list(system, 2.0, 0.0)
+
+        def mic(system, neighbors):
+            return system_to_graph(system, neighbors).edges[0]
+
+        jac_fn = jax.jacrev(mic, argnums=0, allow_int=True)
+
+        fwd = mic(system, neighbors)
+
+        np.testing.assert_allclose(fwd, reference[0, 1])
+
+        jac = jac_fn(system, neighbors)
+
+        assert jac.R[0, 0, 0] == jac.R[1, 0, 1] == jac.R[2, 0, 2]
+        assert jac.R[0, 1, 0] == jac.R[1, 1, 1] == jac.R[2, 1, 2]
+
+        np.testing.assert_allclose(jac.R[0, 0, 0], -1)
+        np.testing.assert_allclose(jac.R[0, 1, 0], +1)
+
+        np.testing.assert_allclose(jac.cell[0, 0, 0], 0, atol=1e-8)
+        np.testing.assert_allclose(jac.cell[1, 1, 0], 0, atol=1e-8)
+        np.testing.assert_allclose(jac.cell[2, 2, 0], 0, atol=1e-8)
+
+        np.testing.assert_allclose(jac.cell[0, 0, 1], -1, atol=1e-8)
+        np.testing.assert_allclose(jac.cell[1, 1, 1], -1, atol=1e-8)
+        np.testing.assert_allclose(jac.cell[2, 2, 1], -1, atol=1e-8)


### PR DESCRIPTION
This PR removes the dependency on `jax-md`. We've had many problems with the unstable dependencies due to `jax-md`, and use very little of its functionality here -- so it doesn't make sense to keep relying on it.

To do this, I had to rewrite `periodic.py`, which now replicates the (little) functionality we previously imported from `jax-md`. The core here is the implementation of how to compute MIC displacements between two positions. In this, I take a different route than `jax-md`:

- `cell` is an explicit argument
- different sign convention
- no custom jvp for the transform into fractional coords

As a result of the last change, the gradients of the new displacements with respect to the cell are now correct. Therefore, we can compute the stress by directly differentiating with respect to positions and cell, which was not previously possible.